### PR TITLE
Simplify value fetching

### DIFF
--- a/plugins/mastodon_streams
+++ b/plugins/mastodon_streams
@@ -13,4 +13,4 @@ EOM
         exit 0;;
 esac
 
-echo "streams.value `netstat -t | grep ':4000 .* ESTABLISHED' | wc -l`"
+echo "streams.value $(ss -o state established '( dport = :4000 )' | wc -l)"


### PR DESCRIPTION
Backticks are bad (http://stackoverflow.com/questions/9405478/command-substitution-backticks-or-dollar-sign-paren-enclosed), and netstat is deprecated (https://dougvitale.wordpress.com/2011/12/21/deprecated-linux-networking-commands-and-their-replacements/).

Using `$()` and `ss` is better 🙂 