### PR TITLE
Add possibility to set the database name

### DIFF
--- a/plugins/mastodon_accounts
+++ b/plugins/mastodon_accounts
@@ -19,14 +19,17 @@ EOM
         exit 0;;
 esac
 
+# default value: mastodon
+DATABASE=${database:-mastodon}
+
 printf "accounts_valid.value "
-echo "SELECT COUNT(*) FROM users WHERE confirmed_at is not null;" | psql mastodon -tq | head -n 1
+echo "SELECT COUNT(*) FROM users WHERE confirmed_at is not null;" | psql $DATABASE -tq | head -n 1
 printf "accounts_waiting.value "
-echo "SELECT COUNT(*) FROM users WHERE confirmed_at is null;" | psql mastodon -tq | head -n 1
+echo "SELECT COUNT(*) FROM users WHERE confirmed_at is null;" | psql $DATABASE -tq | head -n 1
 printf "accounts_remote.value "
-echo "SELECT COUNT(*) FROM accounts WHERE domain is not null;" | psql mastodon -tq | head -n 1
+echo "SELECT COUNT(*) FROM accounts WHERE domain is not null;" | psql $DATABASE -tq | head -n 1
 printf "accounts_remote_domains.value "
-echo "SELECT COUNT(distinct(domain)) FROM accounts WHERE domain is not null;" | psql mastodon -tq | head -n 1
+echo "SELECT COUNT(distinct(domain)) FROM accounts WHERE domain is not null;" | psql $DATABASE -tq | head -n 1
 
 
 

--- a/plugins/mastodon_follows
+++ b/plugins/mastodon_follows
@@ -17,9 +17,12 @@ EOM
         exit 0;;
 esac
 
+# default value: mastodon
+DATABASE=${database:-mastodon}
+
 printf "in_in.value "
-echo "select count(*) from follows f join accounts a on (a.id=account_id) join accounts t on (t.id=target_account_id) where a.domain is null and t.domain is null;" | psql mastodon -tq | head -n 1
+echo "select count(*) from follows f join accounts a on (a.id=account_id) join accounts t on (t.id=target_account_id) where a.domain is null and t.domain is null;" | psql $DATABASE -tq | head -n 1
 printf "in_out.value "
-echo "select count(*) from follows f join accounts a on (a.id=account_id) join accounts t on (t.id=target_account_id) where a.domain is null and t.domain is not null;" | psql mastodon -tq | head -n 1
+echo "select count(*) from follows f join accounts a on (a.id=account_id) join accounts t on (t.id=target_account_id) where a.domain is null and t.domain is not null;" | psql $DATABASE -tq | head -n 1
 printf "out_in.value "
-echo "select count(*) from follows f join accounts a on (a.id=account_id) join accounts t on (t.id=target_account_id) where a.domain is not null and t.domain is null;" | psql mastodon -tq | head -n 1
+echo "select count(*) from follows f join accounts a on (a.id=account_id) join accounts t on (t.id=target_account_id) where a.domain is not null and t.domain is null;" | psql $DATABASE -tq | head -n 1

--- a/plugins/mastodon_statuses
+++ b/plugins/mastodon_statuses
@@ -16,11 +16,14 @@ EOM
 esac
 
 
+# default value: mastodon
+DATABASE=${database:-mastodon}
+
 printf "statuses_total.value "
-echo "SELECT COUNT(*) FROM statuses;" | psql mastodon -tq | head -n 1
+echo "SELECT COUNT(*) FROM statuses;" | psql $DATABASE -tq | head -n 1
 
 printf "statuses_local.value "
-echo "SELECT COUNT(*) FROM statuses AS s, accounts AS a WHERE a.id=s.account_id AND a.domain IS NULL;" | psql mastodon -tq | head -n 1
+echo "SELECT COUNT(*) FROM statuses AS s, accounts AS a WHERE a.id=s.account_id AND a.domain IS NULL;" | psql $DATABASE -tq | head -n 1
 
 
 

--- a/plugins/mastodon_statuses_visibility_local
+++ b/plugins/mastodon_statuses_visibility_local
@@ -16,4 +16,7 @@ EOM
         exit 0;;
 esac
 
-echo "select format('statuses_%s.value %s',vis, coalesce(100*nb/total::numeric,0)) from (select generate_series(0,3) as vis) as v left join (select visibility, count(*) as nb from statuses s join accounts a on (a.id=s.account_id and a.domain is null) where s.created_at > now() - INTERVAL '1 day' group by 1) as s on (vis=visibility), (select count(*) as total from statuses s join accounts a on (a.id=s.account_id and a.domain is null) where s.created_at > now() - INTERVAL '1 day') as t;" | psql mastodon -tA
+# default value: mastodon
+DATABASE=${database:-mastodon}
+
+echo "select format('statuses_%s.value %s',vis, coalesce(100*nb/total::numeric,0)) from (select generate_series(0,3) as vis) as v left join (select visibility, count(*) as nb from statuses s join accounts a on (a.id=s.account_id and a.domain is null) where s.created_at > now() - INTERVAL '1 day' group by 1) as s on (vis=visibility), (select count(*) as total from statuses s join accounts a on (a.id=s.account_id and a.domain is null) where s.created_at > now() - INTERVAL '1 day') as t;" | psql $DATABASE -tA


### PR DESCRIPTION
By default it is "mastodon" but you can set the name by editing the file
/etc/munin/plugin-conf.d/mastodon and use:

[mastodon_*]
user postgres
env.database mastodon_production

to set the database "mastodon_production" instead of 'mastodon".